### PR TITLE
Fix crash when decoding a = at end of the data

### DIFF
--- a/sope-core/NGExtensions/NGQuotedPrintableCoding.m
+++ b/sope-core/NGExtensions/NGQuotedPrintableCoding.m
@@ -147,7 +147,7 @@ int NGDecodeQuotedPrintableX(const char *_src, unsigned _srcLen,
       destCnt++;
     }
     else {
-      if ((_srcLen - cnt) > 1) {
+      if ((_srcLen - cnt) > 2) {
         signed char c1, c2;
 
 	cnt++;          // skip '='


### PR DESCRIPTION
In decoding a quoted printable mail. There is a buffer overflow
as we are always parsing two bytes instead of one.

See the full backtrace at:

https://gist.github.com/sixstone-qq/cb8099b66c2911e8aaf2
