### PR TITLE
Fix encoding in recipients in SOGo

### DIFF
--- a/sope-mime/NGImap4/NGImap4EnvelopeAddress.m
+++ b/sope-mime/NGImap4/NGImap4EnvelopeAddress.m
@@ -97,15 +97,31 @@
 
 - (NSString *)baseEMail {
   NSString *t;
-  
+  NSData *data;
+  NSData *qpData;
+
   if (![self->mailbox isNotEmpty])
     return nil;
   if (![self->host isNotEmpty])
     return self->mailbox;
-  
+
   t = [self->mailbox stringByAppendingString:@"@"];
-  return [t stringByAppendingString:self->host];
+  t = [t stringByAppendingString:self->host];
+
+  /* sometimes mailbox and host come from a splitted quoted printable string */
+  if ([t length] <= 6 /* minimum size */)
+    return t;
+
+  if ([t rangeOfString:@"=?"].length > 0) {
+    data = [t dataUsingEncoding:NSUTF8StringEncoding];
+    if (data != nil) {
+      qpData = [data decodeQuotedPrintableValueOfMIMEHeaderField:@"subject"];
+      if (qpData != data) return qpData;
+    }
+  }
+  return t;
 }
+
 - (NSString *)email {
   NSString *t;
   


### PR DESCRIPTION
It's been noticed that, sometimes (a recipient has an address with an underscore as a name), the IMAP server shows the mailbox and the host of an address as a MIME-encoded string (e.g.: `=?utf-8?q?a=5Fa@a.a?=` -> `mailbox: "=?utf-8?q?a=5Fa"; host: "a.a?="`).

This leads to a wrong behaviour in SOGo, which shows the quoted-printable encoded address instead of the decoded one. This commit (along with https://github.com/Zentyal/sogo/pull/106), fixes this behaviour by decoding the string returned by the `baseEMail` function.