### PR TITLE
Mime address header generation

### DIFF
--- a/sope-mime/NGMail/NGMailAddressParser.m
+++ b/sope-mime/NGMail/NGMailAddressParser.m
@@ -403,7 +403,7 @@ static inline id parseDomainLiteral(NGMailAddressParser *self, BOOL _guessMode) 
     remainder = (NSMutableString *)[remainder stringByTrimmingCharactersInSet:
                             [NSCharacterSet characterSetWithCharactersInString: @","]];
     /* get address part */
-    r = [remainder rangeOfString: @"<"];
+    r = [remainder rangeOfString: @"<" options:NSBackwardsSearch];
     addrStart = r.location;
     if (addrStart == NSNotFound)
       /* Use rest of line as email if there's no '<' */

--- a/sope-mime/NGMime/NGMimeAddressHeaderFieldGenerator.m
+++ b/sope-mime/NGMime/NGMimeAddressHeaderFieldGenerator.m
@@ -84,50 +84,29 @@ static int UseLFSeperatedAddressEntries = -1;
     : [NSClassFromString(@"NGMailAddressParser")
 			mailAddressParserWithData:_value];
 #endif
-  
+
   enumerator = [[parser parseAddressList] objectEnumerator];
   result     = [[NSMutableString alloc] initWithCapacity:128];
 
   while ((address = [enumerator nextObject]) != nil) {
     NSString   *tmp;
-    unichar *uniBuffer;
     char       *buffer;
-    unsigned   bufLen, cnt;
-    BOOL       doEnc;
-    
+    unsigned   bufLen;
+    bool       doEnc;
+
     if ([result length] > 0) {
       if (UseLFSeperatedAddressEntries == 1)
         [result appendString:@",\n   "];
       else
         [result appendString:@", "];
     }
-    
-    tmp    = [address displayName];
-    bufLen = [tmp length];
-    
-    uniBuffer = calloc(bufLen, sizeof(unichar));
-    [tmp getCharacters: uniBuffer];
-    
-    cnt   = 0;
-    doEnc = NO;
-    
-    while (cnt < bufLen) {
-      /* must encode chars outside ASCII 33..60, 62..126 ranges [RFC 2045, Sect. 6.7]
-       * RFC 2047, Sect. 4.2 also requires chars 63 and 95 to be encoded
-       * For spaces, quotation is fine */
-      if (uniBuffer[cnt] < 32 ||
-	  uniBuffer[cnt] == 61 ||
-	  uniBuffer[cnt] == 63 ||
-          uniBuffer[cnt] == 95 ||
-	  uniBuffer[cnt] > 126) {
-        doEnc = YES;
-        break;
-      }
-      cnt++;
-    }
-    
+
+    tmp = [address displayName];
+
+    doEnc = NGEncodeQuotedPrintableMimeNeeded((unsigned char *)[tmp UTF8String],
+                                              [tmp length]);
     buffer = NULL;
-  
+
     if (doEnc) {
       /* FIXME - better use UTF8 encoding! */
 #if NeXT_Foundation_LIBRARY

--- a/sope-mime/NGMime/NGMimeHeaderFieldGenerator.h
+++ b/sope-mime/NGMime/NGMimeHeaderFieldGenerator.h
@@ -83,8 +83,10 @@
 
 @end
 
-extern int NGEncodeQuotedPrintableMime
-(const unsigned char *_src, unsigned _srcLen,
- unsigned char *_dest, unsigned _destLen);
+extern bool NGEncodeQuotedPrintableMimeNeeded(const unsigned char *src,
+                                              unsigned srcLen);
+
+extern int NGEncodeQuotedPrintableMime(const unsigned char *src, unsigned srcLen,
+                                       unsigned char *dest, unsigned destLen);
 
 #endif // __NGMime_NGHeaderFieldGenerator_H__


### PR DESCRIPTION
Two fixes related with mime mail headers (from, to, cc, ...):

 * Parse emails with '<' on display name.
 * QP encode header more strictly using rfc822 [atom](http://www.w3.org/Protocols/rfc822/#z66) description because that's how [dovecot](http://hg.dovecot.org/dovecot-2.2/file/0bbdc413285e/src/lib-mail/message-address.c#l49) will parse these fields.