### PR TITLE
Use same way to get NSStringEncoding in similar methods

### DIFF
--- a/sope-core/NGExtensions/FdExt.subproj/NSString+Encoding.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSString+Encoding.m
@@ -49,8 +49,7 @@
 + (NSStringEncoding)stringEncodingForEncodingNamed:(NSString *)_encoding
 {
   CFStringEncoding cfEncoding;
-
-  if(_encoding == nil)
+  if (_encoding == nil)
     return 0;
 
   _encoding = [_encoding lowercaseString];
@@ -87,7 +86,10 @@
 #if GNUSTEP_BASE_LIBRARY
 
 + (NSStringEncoding)stringEncodingForEncodingNamed:(NSString *)_encoding {
-  return [GSMimeDocument encodingFromCharset:_encoding];
+    if (_encoding == nil)
+      return 0;
+
+    return [GSMimeDocument encodingFromCharset:_encoding];
 }
 
 #endif
@@ -97,7 +99,7 @@
 + (NSStringEncoding)stringEncodingForEncodingNamed:(NSString *)_encoding {
   NSString *s  = [_encoding lowercaseString];
   unsigned len = [s length];
-  
+
   if (s == nil)
     return 0;
 
@@ -105,6 +107,8 @@
   case 4:
     if ([s isEqualToString:@"utf8"])
       return NSUTF8StringEncoding;
+    if ([s isEqualToString:@"big5"]) 
+      return NSBIG5StringEncoding;
     break;
     
   case 5:
@@ -119,16 +123,76 @@
       return NSISOLatin1StringEncoding;
     if ([s isEqualToString:@"latin9"])
       return NSISOLatin9StringEncoding;
+    if ([s isEqualToString:@"utf-16"])
+      return NSUnicodeStringEncoding;
+    if ([s isEqualToString:@"8859-1"])
+      return NSISOLatin1StringEncoding;
+    if ([s isEqualToString:@"euc-kr"])
+      return NSKoreanEUCStringEncoding;
+    if ([s isEqualToString:@"koi8-r"])
+      return NSKOI8RStringEncoding;
+    if ([s isEqualToString:@"gb2312"])
+      return NSGB2312StringEncoding;
+    
+    break;
+
+  case 7:
+    if ([s isEqualToString:@"unknown"])
+      return NSISOLatin1StringEncoding;
+    if ([s isEqualToString:@"8859-15"])
+      return NSISOLatin9StringEncoding;
+
+  case 8:
+    if ([s isEqualToString:@"us-ascii"])
+      return NSASCIIStringEncoding;
+    break;
+
+  case 9:
+    if ([s isEqualToString:@"x-unknown"])
+      return NSISOLatin1StringEncoding;
     break;
 
   case 10:
     if ([s isEqualToString:@"iso-8859-1"]) 
       return NSISOLatin1StringEncoding;
+    if ([s isEqualToString:@"iso-8859-5")    
+        return NSISOCyrillicStringEncoding    
+    if ([s isEqualToString:@"iso-8859-2"])
+      return NSISOLatin2StringEncoding;
+    if ([s isEqualToString:@"iso-8859-7"])
+      return NSISOGreekStringEncoding;
+    if ([s isEqualToString:@"iso-8859-6"])
+      return NSISOArabicStringEncoding;
+    if ([s isEqualToString:@"iso-8859-4"])
+      return NSISOLatin4StringEncoding;
+    if ([s isEqualToString:@"iso-8859-9"])
+      return NSISOLatin5StringEncoding;    
     break;
     
   case 11:
     if ([s isEqualToString:@"iso-8859-15"]) 
       return NSISOLatin9StringEncoding;
+    if ([s isEqualToString:@"iso-latin-1"])
+      return NSISOLatin1StringEncoding;
+    if ([s isEqualToString:@"iso-2022-jp"])
+      return NSISO2022JPStringEncoding;
+    break;
+
+  case 12:
+    if ([s isEqualToString:@"windows-1252"])
+      return NSWindowsCP1252StringEncoding;
+    if ([s isEqualToString:@"windows-1251"])
+      return NSWindowsCP1251StringEncoding;
+    if ([s isEqualToString:@"windows-1250"])
+      return NSWindowsCP1250StringEncoding;    
+    if ([s isEqualToString:@"iso-8859-8-i"])
+      return NSISOHebrewStringEncoding;    
+    break;
+
+  case 14:
+    // unsupported but knwon
+    if ([s isEqualToString:@"ks_c_5601-1987"])
+      return NSISOLatin1StringEncoding;
     break;
   }
   

--- a/sope-mime/NGMime/NGMimeType.m
+++ b/sope-mime/NGMime/NGMimeType.m
@@ -18,6 +18,7 @@
   Free Software Foundation, 59 Temple Place - Suite 330, Boston, MA
   02111-1307, USA.
 */
+#import <NGExtensions/NSString+Encoding.h>
 
 #include "NGMimeType.h"
 #include "NGConcreteMimeType.h"
@@ -89,96 +90,21 @@ static Class NSStringClass  = Nil;
 }
 
 + (NSStringEncoding)stringEncodingForCharset:(NSString *)_s {
-  NSString         *charset;
   NSStringEncoding encoding;
 
-  charset          = [_s lowercaseString];
-  
-  if ([charset length] == 0)
+  if ([_s length] == 0)
     encoding = [NSString defaultCStringEncoding];
-  
-  /* UTF-, ASCII */
-  else if ([charset isEqualToString:@"us-ascii"])
-    encoding = NSASCIIStringEncoding;
-  else if ([charset isEqualToString:@"utf-8"])
-    encoding = NSUTF8StringEncoding;
-  else if ([charset isEqualToString:@"utf-16"])
-    encoding = NSUnicodeStringEncoding;
+  else
+    {
+      encoding = [NSString stringEncodingForEncodingNamed: _s];
+      if (encoding == 0)
+        {
+          [self logWithFormat:@"%s: unknown charset '%@'",
+                __PRETTY_FUNCTION__, _s];
+          encoding = NSISOLatin1StringEncoding;
+        }
+    }
 
-  /* ISO Latin 1 */
-  else if ([charset isEqualToString:@"iso-latin-1"])
-    encoding = NSISOLatin1StringEncoding;
-  else if ([charset isEqualToString:@"iso-8859-1"])
-    encoding = NSISOLatin1StringEncoding;
-  else if ([charset isEqualToString:@"8859-1"])
-    encoding = NSISOLatin1StringEncoding;
-  
-  /* some unsupported, but known encoding */
-  else if ([charset isEqualToString:@"ks_c_5601-1987"]) {
-    encoding = NSISOLatin1StringEncoding;
-  }
-  else if ([charset isEqualToString:@"euc-kr"]) {
-    encoding = NSKoreanEUCStringEncoding;
-  }
-  else if ([charset isEqualToString:@"big5"]) {
-    encoding = NSBIG5StringEncoding;
-  }
-  else if ([charset isEqualToString:@"iso-2022-jp"]) {
-    encoding = NSISO2022JPStringEncoding;
-  }
-  else if ([charset isEqualToString:@"gb2312"]) {
-    encoding = NSGB2312StringEncoding;
-  }
-  else if ([charset isEqualToString:@"koi8-r"]) {
-    encoding = NSKOI8RStringEncoding;
-  }
-  else if ([charset isEqualToString:@"windows-1250"]) {
-    encoding = NSWindowsCP1250StringEncoding;
-  }
-  else if ([charset isEqualToString:@"windows-1251"]) {
-    encoding = NSWindowsCP1251StringEncoding;
-  }
-  else if ([charset isEqualToString:@"windows-1252"]) {
-    encoding = NSWindowsCP1252StringEncoding;
-  }
-  else if ([charset isEqualToString:@"iso-8859-2"]) {
-    encoding = NSISOLatin2StringEncoding;
-  }
-  else if ([charset isEqualToString:@"iso-8859-8-i"]) {
-    encoding = NSISOHebrewStringEncoding;
-  }
-  else if ([charset isEqualToString:@"iso-8859-7"]) {
-    encoding = NSISOGreekStringEncoding;
-  }
-  else if ([charset isEqualToString:@"iso-8859-6"]) {
-    encoding = NSISOArabicStringEncoding;
-  }
-  else if ([charset isEqualToString:@"iso-8859-4"]) {
-    // latin 4 is for baltic languages
-    encoding = NSISOLatin4StringEncoding;
-  }
-  else if ([charset isEqualToString:@"iso-8859-9"]) {
-    // latin 5 is for turkish languages
-    encoding = NSISOLatin5StringEncoding;
-  }
-  else if ([charset isEqualToString:@"x-unknown"] ||
-           [charset isEqualToString:@"unknown"]) {
-    encoding = NSISOLatin1StringEncoding;
-  }
-  /* ISO Latin 9 */
-#if !(NeXT_Foundation_LIBRARY || APPLE_Foundation_LIBRARY)
-  else if ([charset isEqualToString:@"iso-latin-9"])
-    encoding = NSISOLatin9StringEncoding;
-  else if ([charset isEqualToString:@"iso-8859-15"])
-    encoding = NSISOLatin9StringEncoding;
-  else if ([charset isEqualToString:@"8859-15"])
-    encoding = NSISOLatin9StringEncoding;
-#endif
-  else {
-    [self logWithFormat:@"%s: unknown charset '%@'",
-          __PRETTY_FUNCTION__, _s];
-    encoding = NSISOLatin1StringEncoding;
-  }
   return encoding;
 }
 


### PR DESCRIPTION
Currently there are two methods to get the NSStringEncoding
from a named encoding [NGMime stringEncodingForCharset:] and
[NSString stringEncodingForEncodingNamed:] this two are not
only redundant but use a different way to match the NSStringEncoding
with its name. This can spell difficult to trace bugs.

[NGMime stringEncodingForCharset:] uses a hardcoded table.

[NSString stringEncodingForEncodingNamed:] depends on the system,
compiled with GNUStep uses a call to GSMimeDocument.

This commit makes [NGMime stringEncodingForCharset:] to call
[NSString stringEncodingForEncodingNamed:] to assure we use
the same resolution method.

This does not make the methods totally equivalent, with unknown
encodings [NSString stringEncodingForEncodingNamed:] returns 0
but [NGMime stringEncodingForCharset:] returns either
NSISOLatin1StringEncoding or [NSString defaultCStringEncoding].
The last value is returned for nil or empty charset names.

If this changset is accepted, the next step would be to replace
calls to [NGMime stringEncodingForCharset:] with
[NSString stringEncodingForEncodingNamed:] calls.
